### PR TITLE
Add blank error code to HotelSpec.groovy

### DIFF
--- a/complete/src/test/groovy/demo/HotelSpec.groovy
+++ b/complete/src/test/groovy/demo/HotelSpec.groovy
@@ -34,6 +34,7 @@ class HotelSpec extends Specification implements DomainUnitTest<Hotel> {
 
         then:
         !domain.validate(['name'])
+        domain.errors['name'].code == 'blank'
     }
 
     void 'test name can have a maximum of 255 characters'() {


### PR DESCRIPTION
Update the Grails Guide unit test to show that the domain error code is 'blank' when a domain property validation fails due to it being an empty string.

I know this works on Grails 5.2.1 applications with GORM 7.3.2.

I didn't create a Grails 5.0.1 application to confirm it works in there as well.